### PR TITLE
Fixed firefox SyntaxError

### DIFF
--- a/src/peapod/styler.jsx
+++ b/src/peapod/styler.jsx
@@ -574,7 +574,7 @@ window.Pod_Styler = window.Pod_Styler || {
 
 					for (var i = 0, len = matches.length; i < len; i++) {
 						var match = matches[i];
-					    computedVar = computedVar.replace(match, Pod_Vars.get(match.replace('{$', '').replace('}', '')), varSet);
+					    computedVar = computedVar.replace(match, Pod_Vars.get(match.replace('{$', '').replace('}', '')));
 					}
 				} else { // simple Pod_Vars.get on whole value
 					computedVar = Pod_Vars.get(computedVar.replace('$', ''), varSet);


### PR DESCRIPTION
This was very likely a typo - `varSet` as third parameter in
`.replace()`.
[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Firefox-specific_notes)
