### PR TITLE
fixed syntax error in Firefox caused by Styler

### DIFF
--- a/src/peapod/components.jsx
+++ b/src/peapod/components.jsx
@@ -56,5 +56,3 @@ var base = require('./theme/base.jsx');
 base(components);
 
 module.exports = [Pod, Pod_Vars, Pod_Styler, components];
-
-console.log(exports);

--- a/src/peapod/styler.jsx
+++ b/src/peapod/styler.jsx
@@ -509,12 +509,12 @@ window.Pod_Styler = window.Pod_Styler || {
 		return style;
 	},
 
-	parseVariableValue: function(computedVar, obj, varSet) {
+	parseVariableValue: function(computedVar, obj, scene) {
 		var styler = obj.styler || {};
 
 		if (typeof(computedVar) == 'array') {
 			for (var computedIndex = computedVar.length - 1; computedIndex >= 0; computedIndex--) { // go through in reverse order to find most specific
-				if (computedVar[computedIndex].vars == varSet || computedVar[computedIndex].vars == "global") {
+				if (computedVar[computedIndex].vars == scene || computedVar[computedIndex].vars == "global") {
 					computedVar = computedVar[computedIndex].val;
 					break;
 				}
@@ -522,29 +522,29 @@ window.Pod_Styler = window.Pod_Styler || {
 		}
 
 		if (typeof(computedVar) == 'string') {
-			computedVar = Pod_Styler.processVariableString(computedVar, obj, varSet);
+			computedVar = Pod_Styler.processVariableString(computedVar, obj, scene);
 		}
 		return computedVar;
 	},
 
-	processVariableString: function(computedVar, obj, varSet) {
+	processVariableString: function(computedVar, obj, scene) {
 		if (computedVar.indexOf('$') > -1) {
 			var computedKey = computedVar;
-			if (typeof(this.varCache[computedVar + '_' + varSet]) == 'undefined') {
+			if (typeof(this.varCache[computedVar + '_' + scene]) == 'undefined') {
 				if (computedVar.indexOf('{') > -1 && computedVar.indexOf('}') > -1) { // RegEx based Pod_Vars.get
 					var regEx = /\{\$\S*\}/g,
 						matches = computedVar.match(regEx);
 
 					for (var i = 0, len = matches.length; i < len; i++) {
 						var match = matches[i];
-					    computedVar = computedVar.replace(match, Pod_Vars.get(match.replace('{$', '').replace('}', '')), varSet);
+					    computedVar = computedVar.replace(match, Pod_Vars.get(match.replace('{$', '').replace('}', ''), scene));
 					}
 				} else { // simple Pod_Vars.get on whole value
-					computedVar = Pod_Vars.get(computedVar.replace('$', ''), varSet);
+					computedVar = Pod_Vars.get(computedVar.replace('$', ''), scene);
 				}
-				this.varCache[computedKey + '_' + varSet] = computedVar;
+				this.varCache[computedKey + '_' + scene] = computedVar;
 			} else {
-				computedVar = this.varCache[computedKey + '_' + varSet]; // get variable from cache rather than parse string
+				computedVar = this.varCache[computedKey + '_' + scene]; // get variable from cache rather than parse string
 			}
 		} else if (computedVar.indexOf('getProp:') > -1) {
 			computedVar = obj.props[computedVar.replace('getProp:', '')];


### PR DESCRIPTION
Had a `varSet` inside a `replace` instead of `Pod_Vars.get`.  Fixes #8 
